### PR TITLE
Updated Jenkinsfiles to use a Docker container providing Java OpenJDK 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 	}
   
 	environment {
-		DOCKER_CONTAINER = 'kieker/kieker-build:ta-v3'
+		DOCKER_CONTAINER = 'openjdk:11-jdk-slim'
 	}
 	
 	stages {

--- a/Jenkinsfile-Windows
+++ b/Jenkinsfile-Windows
@@ -3,7 +3,7 @@ pipeline {
 	agent any
   
 	environment {
-		DOCKER_CONTAINER = 'kieker/kieker-build:ta-v3'
+		DOCKER_CONTAINER = 'openjdk:11-jdk-slim'
 	}
 	
 	stages {


### PR DESCRIPTION
In order to use Java OpenJDK 11, the Docker container definition in the Jenkinsfiles needed to be updated. As only plain OpenJDK 11 is needed for the build, it was not necessary to use a custom-built container this time. To keep the size of the container possibly small, the openjdk:11-jdk-small image was chosen.