### PR TITLE
Introduce build timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,11 @@ pipeline {
 	environment {
 		DOCKER_CONTAINER = 'openjdk:11-jdk-slim'
 	}
-	
+
+  options {
+    timeout(time: 15, unit: 'MINUTES')
+  }
+
 	stages {
 		
 		stage('Docker Pull') {


### PR DESCRIPTION
In order to prevent builds that have issues from hanging forever, it would make sense to introduce a timeout that lets the build fail in case it takes longer than the designated duration.
Currently, it is set to 15 minutes (normal, successful builds seem to take about 2 minutes).